### PR TITLE
feat: Performance Enhancement: useCallback for Event Handlers

### DIFF
--- a/src/components/InvoiceForm.tsx
+++ b/src/components/InvoiceForm.tsx
@@ -44,6 +44,8 @@ import {
 } from "@/lib/helper";
 import i18nIsoCountries from "i18n-iso-countries";
 import enCountries from "i18n-iso-countries/langs/en.json";
+import { useCallback } from 'react';
+
 
 type CountryOption = {
   value: Country;
@@ -73,10 +75,10 @@ const InvoiceForm = () => {
     getExampleNumber(country.value, examples)!.formatInternational()
   );
 
-  const onCountryChange = (value: CountryOption) => {
+  const onCountryChange = useCallback((value: CountryOption) => {
     setPhoneNumber(undefined);
     setCountry(value);
-  };
+  },[setPhoneNumber, setCountry]);
 
   const form = useForm<TInvoiceSchema>({
     resolver: zodResolver(invoiceSchema),


### PR DESCRIPTION
Reason: Wrapping the function in useCallback prevents it from being re-created on every render, which is especially helpful for performance in larger apps.